### PR TITLE
  - config.paranoid = true : empêche l'énumération de comptes sur le

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,12 +89,13 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts = [
+    "maximeoudin.fr",
+    "www.maximeoudin.fr"
+  ]
+
+  # Skip DNS rebinding protection for the default health check endpoint
+  # (Kamal/proxy probes "/up" with the container's internal host).
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 12..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
    flux de récupération de mot de passe
  - password_length 6..128 -> 12..128
  - production: config.hosts en allowlist (maximeoudin.fr, www) + exclusion de /up pour les health checks Kamal (anti DNS-rebinding)